### PR TITLE
Firefox Support via WebExtensions

### DIFF
--- a/ModernDeck/extension/TDELoad.js
+++ b/ModernDeck/extension/TDELoad.js
@@ -30,12 +30,10 @@ function InjectDevStyles() {
   injStyles = document.createElement("link");
   injStyles.rel = "stylesheet";
 
-  if (isChromium) {
+  if (isChromium || isFirefox) {
     injStyles.href = chrome.extension.getURL("sources/enhancer.css");
   } else if (isSafari) {
     injStyles.href = safari.extension.baseURI + "sources/enhancer.css";
-  } else if (isFirefox) {
-    injStyles.href = self.options.ffTDEURLExchange + "sources/enhancer.css";
   } else {
     console.log('you done goofed')
   }
@@ -62,15 +60,12 @@ function TDEURLExchange(url) {
   console.log("injected url exchange with id " + injurl.id);
 }
 
-if (isChromium) {
+if (isChromium || isFirefox) {
   TDEURLExchange(chrome.extension.getURL(""));
   InjectScript.src = chrome.extension.getURL("sources/TDEinject.js");
 } else if (isSafari) {
   TDEURLExchange(safari.extension.baseURI + "/");
   InjectScript.src = safari.extension.baseURI + "sources/TDEinject.js";
-} else {
-  TDEURLExchange(self.options.ffTDEURLExchange);
-  InjectScript.src = self.options.ffTDEURLExchange + "sources/TDEinject.js";
 }
 
 InjectScript.type = "text/javascript";

--- a/ModernDeck/manifest.json
+++ b/ModernDeck/manifest.json
@@ -26,8 +26,7 @@
   ],
 
   "background": {
-    "scripts": ["extension/TDEBackground.js"],
-    "persistent": true
+    "scripts": ["extension/TDEBackground.js"]
   },
 
   "icons": {
@@ -42,7 +41,30 @@
 
   "web_accessible_resources": [
     "sources",
-    "sources/*"
+    "sources/*",
+    "sources/TDEinject.js",
+    "sources/enhancer.css",
+    "sources/enhancer.min.css",
+    "sources/accounts.png",
+    "sources/AddColumn.png",
+    "sources/alert_2.mp3",
+    "sources/BTDsmall.png",
+    "sources/favicon.ico",
+    "sources/KBshortcuts.png",
+    "sources/logout.png",
+    "sources/mtdabout.png",
+    "sources/TDEsmall.png",
+    "sources/TweetDeck.png",
+    "sources/tweetdecksmall.png",
+    "sources/fonts/Roboto300latinext.woff2",
+    "sources/fonts/Roboto300latin.woff2",
+    "sources/fonts/Roboto400latinext.woff2",
+    "sources/fonts/Roboto400latin.woff2",
+    "sources/fonts/Roboto500latinext.woff2",
+    "sources/fonts/Roboto500latin.woff2",
+    "sources/fonts/MaterialIcons.woff2",
+    "sources/fonts/fontawesome.woff2",
+    "sources/fonts/MaterialIcons.woff2"
   ],
 
   "browser_action": {
@@ -51,5 +73,13 @@
     "default_title": "__MSG_ButtonHoverTitle__"
   },
 
-  "manifest_version": 2
+  "manifest_version": 2,
+
+  "applications": {
+    "gecko": {
+      "id": "ModernDeck@ModernDeck.com",
+      "strict_min_version": "42.0",
+      "strict_max_version": "*"
+    }
+  }
 }

--- a/ModernDeck/sources/TDEinject.js
+++ b/ModernDeck/sources/TDEinject.js
@@ -112,14 +112,6 @@ function TDEInit(){
 		document.head.appendChild(injStyles);
 	}*/
 
-	if(TreatGeckoWithCare == true)
-	{
-		InjectFonts = document.createElement("link");
-		InjectFonts.rel = "stylesheet";
-		InjectFonts.href = TDEBaseURL + "sources/fonts/fonts.css";
-	}
-	else
-	{
 	InjectFonts = document.createElement("style");
 	InjectFonts.innerHTML = "\
 	@font-face {\
@@ -176,7 +168,6 @@ function TDEInit(){
 		font-weight: 400;\
 		src: url(" + TDEBaseURL + "sources/fonts/fontawesome.woff2) format('woff2');\
 	}";
-	}
 
 
 	document.head.appendChild(InjectFonts);


### PR DESCRIPTION
Unfortunately Firefox doesn't allow wildcards in web_accessible_resources yet, nor will it support the persistent flag on background (due to all background scripts being persistent). This also fixes the font issue, since it was trying to inject a non-existent CSS instead of injecting the styles directly.