### PR TITLE
Fix the drawer button

### DIFF
--- a/ModernDeck/sources/enhancer.css
+++ b/ModernDeck/sources/enhancer.css
@@ -8889,7 +8889,8 @@ a[rel=hashtag]:active {
 	z-index:9;
 	transform:scale(0.5);
 	opacity:0;
-	transition:500ms all,150ms opacity
+	transition:500ms all,150ms opacity;
+	pointer-events:none
 }
 
 


### PR DESCRIPTION
Because 'click' events only propagate on a `mousedown` and `mouseup` on the same element and the :after  was moving into the way. So let's just have it ignore pointer events!