### PR TITLE
Firefox Support via WebExtensions

### DIFF
--- a/ModernDeck/manifest.json
+++ b/ModernDeck/manifest.json
@@ -29,8 +29,7 @@
   ],
 
   "background": {
-    "scripts": ["extension/MTDBackground.js"],
-    "persistent": true
+    "scripts": ["extension/MTDBackground.js"]
   },
 
   "icons": {
@@ -45,7 +44,31 @@
 
   "web_accessible_resources": [
     "sources",
-    "sources/*"
+    "sources/*",
+    "sources/MTDinject.js",
+    "sources/moderndeck.css",
+    "sources/moderndeck.min.css",
+    "sources/accounts.png",
+    "sources/AddColumn.png",
+    "sources/alert_2.mp3",
+    "sources/BTDsmall.png",
+    "sources/dev.css",
+    "sources/favicon.ico",
+    "sources/KBshortcuts.png",
+    "sources/logout.png",
+    "sources/mtdabout.png",
+    "sources/MTDsmall.png",
+    "sources/TweetDeck.png",
+    "sources/tweetdecksmall.png",
+    "sources/fonts/Roboto300latinext.woff2",
+    "sources/fonts/Roboto300latin.woff2",
+    "sources/fonts/Roboto400latinext.woff2",
+    "sources/fonts/Roboto400latin.woff2",
+    "sources/fonts/Roboto500latinext.woff2",
+    "sources/fonts/Roboto500latin.woff2",
+    "sources/fonts/MaterialIcons.woff2",
+    "sources/fonts/fontawesome.woff2",
+    "sources/fonts/MaterialIcons.woff2"
   ],
 
   "browser_action": {
@@ -54,5 +77,13 @@
     "default_title": "Launch TweetDeck"
   },
 
-  "manifest_version": 2
+  "manifest_version": 2,
+
+  "applications": {
+    "gecko": {
+      "id": "ModernDeck@ModernDeck.com",
+      "strict_min_version": "42.0",
+      "strict_max_version": "*"
+    }
+  }
 }


### PR DESCRIPTION
`persistent` isn't supported on Firefox, all background scripts are persistent, and Firefox doesn't support wildcards for `web_accessible_resources` (yet).