### PR TITLE
Remove expired URL from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ ModernDeck
 
 An extension that adds nice things to TweetDeck, like a material design interface.
 
-[https://tweetdeckenhancer.com](https://tweetdeckenhancer.com)
-
 Installation
 ==================
 


### PR DESCRIPTION
The tweetdeckenchancer.com domain has expired, no point keeping in the readme.
